### PR TITLE
Pushable thumb controls and disabling overlapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please check Demo project for a basic example on how to use MARKRangeSlider.
 - `leftValue` - the value of the left thumb
 - `rightValue` - the value of the right thumb
 - `minimumDistance` - the distance between 2 thumbs (thumbs can't be closer to each other than this distance)
+- 'pushable' - allows the user to push both controls
+- 'disableOverlapping' - disables the overlaping of thumb controls
 
 ## Available styling properties
 Images are customizable, default ones are used when no image is provided.

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -12,7 +12,7 @@
 @property (nonatomic, assign) CGFloat minimumDistance;
 
 @property (nonatomic) BOOL pushable;
-@property (nonatomic) BOOL trackByEdges;
+@property (nonatomic) BOOL disableOverlapping;
 
 // Images
 @property (nonatomic) UIImage *trackImage;

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -12,6 +12,7 @@
 @property (nonatomic, assign) CGFloat minimumDistance;
 
 @property (nonatomic) BOOL pushable;
+@property (nonatomic) BOOL trackByEdges;
 
 // Images
 @property (nonatomic) UIImage *trackImage;

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -11,6 +11,8 @@
 
 @property (nonatomic, assign) CGFloat minimumDistance;
 
+@property (nonatomic) BOOL pushable;
+
 // Images
 @property (nonatomic) UIImage *trackImage;
 @property (nonatomic) UIImage *rangeImage;

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -1,4 +1,5 @@
 #import "MARKRangeSlider.h"
+#import "ADToolTipView.h"
 
 static NSString * const kMARKRangeSliderThumbImage = @"rangeSliderThumb.png";
 static NSString * const kMARKRangeSliderTrackImage = @"rangeSliderTrack.png";
@@ -113,7 +114,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 
     CGFloat leftAvailableWidth = width - leftThumbImageSize.width;
     CGFloat rightAvailableWidth = width - rightThumbImageSize.width;
-    if (self.trackByEdges) {
+    if (self.disableOverlapping) {
         leftAvailableWidth -= leftThumbImageSize.width;
         rightAvailableWidth -= rightThumbImageSize.width;
     }
@@ -139,7 +140,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     // Set track frame
     CGFloat trackX = gap;
     CGFloat trackWidth = width - gap*2;
-    if (self.trackByEdges) {
+    if (self.disableOverlapping) {
         trackX += leftInset;
         trackWidth -= leftInset+rightInset;
     }
@@ -147,7 +148,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 
     // Set range frame
     CGFloat rangeWidth = rightX - leftX;
-    if (self.trackByEdges) {
+    if (self.disableOverlapping) {
         rangeWidth += rightInset + gap;
     }
     self.rangeImageView.frame = CGRectMake(leftX + leftInset, trackY, rangeWidth, kMARKRangeSliderTrackHeight);
@@ -155,7 +156,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     // Set left & right thumb frames
     leftX += leftInset;
     rightX += rightInset;
-    if (self.trackByEdges) {
+    if (self.disableOverlapping) {
         rightX = rightX + rightInset*2 - gap;
     }
     self.leftThumbImageView.center = CGPointMake(leftX, height / 2);

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -1,5 +1,4 @@
 #import "MARKRangeSlider.h"
-#import "ADToolTipView.h"
 
 static NSString * const kMARKRangeSliderThumbImage = @"rangeSliderThumb.png";
 static NSString * const kMARKRangeSliderTrackImage = @"rangeSliderTrack.png";
@@ -98,7 +97,6 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     // Add right pan recognizer
     UIPanGestureRecognizer *rightPanRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleRightPan:)];
     [self.rightThumbImageView addGestureRecognizer:rightPanRecognizer];
-    
 }
 
 #pragma mark - Layout
@@ -139,10 +137,10 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 
     // Set track frame
     CGFloat trackX = gap;
-    CGFloat trackWidth = width - gap*2;
+    CGFloat trackWidth = width - gap * 2;
     if (self.disableOverlapping) {
         trackX += leftInset;
-        trackWidth -= leftInset+rightInset;
+        trackWidth -= leftInset + rightInset;
     }
     self.trackImageView.frame = CGRectMake(trackX, trackY, trackWidth, kMARKRangeSliderTrackHeight);
 
@@ -157,7 +155,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     leftX += leftInset;
     rightX += rightInset;
     if (self.disableOverlapping) {
-        rightX = rightX + rightInset*2 - gap;
+        rightX = rightX + rightInset * 2 - gap;
     }
     self.leftThumbImageView.center = CGPointMake(leftX, height / 2);
     self.rightThumbImageView.center = CGPointMake(rightX, height / 2);
@@ -287,11 +285,10 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 - (void)setLeftValue:(CGFloat)leftValue
 {
     CGFloat allowedValue = self.rightValue - self.minimumDistance;
-    
     if (leftValue > allowedValue) {
         if (self.pushable) {
             CGFloat rightSpace = self.maximumValue - self.rightValue;
-            CGFloat deltaLeft = leftValue - _leftValue;
+            CGFloat deltaLeft = self.minimumDistance - (self.rightValue - leftValue);
             if (deltaLeft > 0 && rightSpace > deltaLeft) {
                 self.rightValue += deltaLeft;
             }
@@ -322,7 +319,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     if (rightValue < allowedValue) {
         if (self.pushable) {
             CGFloat leftSpace = self.leftValue - self.minimumValue;
-            CGFloat deltaRight = _rightValue - rightValue;
+            CGFloat deltaRight = self.minimumDistance - (rightValue - self.leftValue);
             if (deltaRight > 0 && leftSpace > deltaRight) {
                 self.leftValue -= deltaRight;
             }

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -97,6 +97,7 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     // Add right pan recognizer
     UIPanGestureRecognizer *rightPanRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleRightPan:)];
     [self.rightThumbImageView addGestureRecognizer:rightPanRecognizer];
+    
 }
 
 #pragma mark - Layout
@@ -112,6 +113,10 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 
     CGFloat leftAvailableWidth = width - leftThumbImageSize.width;
     CGFloat rightAvailableWidth = width - rightThumbImageSize.width;
+    if (self.trackByEdges) {
+        leftAvailableWidth -= leftThumbImageSize.width;
+        rightAvailableWidth -= rightThumbImageSize.width;
+    }
 
     CGFloat leftInset = leftThumbImageSize.width / 2;
     CGFloat rightInset = rightThumbImageSize.width / 2;
@@ -132,15 +137,29 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
     CGFloat gap = 1.0;
 
     // Set track frame
-    self.trackImageView.frame = CGRectMake(gap, trackY, width - gap, kMARKRangeSliderTrackHeight);
+    CGFloat trackX = gap;
+    CGFloat trackWidth = width - gap*2;
+    if (self.trackByEdges) {
+        trackX += leftInset;
+        trackWidth -= leftInset+rightInset;
+    }
+    self.trackImageView.frame = CGRectMake(trackX, trackY, trackWidth, kMARKRangeSliderTrackHeight);
 
     // Set range frame
     CGFloat rangeWidth = rightX - leftX;
+    if (self.trackByEdges) {
+        rangeWidth += rightInset + gap;
+    }
     self.rangeImageView.frame = CGRectMake(leftX + leftInset, trackY, rangeWidth, kMARKRangeSliderTrackHeight);
 
     // Set left & right thumb frames
-    self.leftThumbImageView.center = CGPointMake(leftX + leftInset, height / 2);
-    self.rightThumbImageView.center = CGPointMake(rightX + rightInset, height / 2);
+    leftX += leftInset;
+    rightX += rightInset;
+    if (self.trackByEdges) {
+        rightX = rightX + rightInset*2 - gap;
+    }
+    self.leftThumbImageView.center = CGPointMake(leftX, height / 2);
+    self.rightThumbImageView.center = CGPointMake(rightX, height / 2);
 }
 
 #pragma mark - Gesture recognition

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -267,8 +267,21 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 - (void)setLeftValue:(CGFloat)leftValue
 {
     CGFloat allowedValue = self.rightValue - self.minimumDistance;
+    
     if (leftValue > allowedValue) {
-        leftValue = allowedValue;
+        if (self.pushable) {
+            CGFloat rightSpace = self.maximumValue - self.rightValue;
+            CGFloat deltaLeft = leftValue - _leftValue;
+            if (deltaLeft > 0 && rightSpace > deltaLeft) {
+                self.rightValue += deltaLeft;
+            }
+            else {
+                leftValue = allowedValue;
+            }
+        }
+        else {
+            leftValue = allowedValue;
+        }
     }
 
     if (leftValue < self.minimumValue) {
@@ -287,7 +300,19 @@ static CGFloat const kMARKRangeSliderTrackHeight = 2.0;
 {
     CGFloat allowedValue = self.leftValue + self.minimumDistance;
     if (rightValue < allowedValue) {
-        rightValue = allowedValue;
+        if (self.pushable) {
+            CGFloat leftSpace = self.leftValue - self.minimumValue;
+            CGFloat deltaRight = _rightValue - rightValue;
+            if (deltaRight > 0 && leftSpace > deltaRight) {
+                self.leftValue -= deltaRight;
+            }
+            else {
+                rightValue = allowedValue;
+            }
+        }
+        else {
+            rightValue = allowedValue;
+        }
     }
 
     if (rightValue > self.maximumValue) {

--- a/Tests/Tests/MARKRangeSliderTests.m
+++ b/Tests/Tests/MARKRangeSliderTests.m
@@ -120,6 +120,24 @@
 
 #pragma mark - Left value tests
 
+- (void)testSetLeftValuePushesRightValue
+{
+    self.rangeSlider.pushable = YES;
+    self.rangeSlider.rightValue = 0.7;
+    self.rangeSlider.minimumDistance = 0.2;
+    self.rangeSlider.leftValue = 0.6;
+    XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should be equal to left value plus minimum distance");
+}
+
+- (void)testSetLeftValueDoesntPushRightValue
+{
+    self.rangeSlider.pushable = YES;
+    self.rangeSlider.rightValue = 1.0;
+    self.rangeSlider.minimumDistance = 0.2;
+    self.rangeSlider.leftValue = 0.9;
+    XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should be equal to right value minus minimum distance");
+}
+
 - (void)testSetLeftValueExceedsMinimumDistance
 {
     self.rangeSlider.rightValue = 1.0;
@@ -150,6 +168,24 @@
 }
 
 #pragma mark - Right value tests
+
+- (void)testSetRightValuePushesLeftValue
+{
+    self.rangeSlider.pushable = YES;
+    self.rangeSlider.minimumDistance = 0.2;
+    self.rangeSlider.leftValue = 0.6;
+    self.rangeSlider.rightValue = 0.7;
+    XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should be equal to right value minus minimum distance");
+}
+
+- (void)testSetRightValueDoesntPushLeftValue
+{
+    self.rangeSlider.pushable = YES;
+    self.rangeSlider.minimumDistance = 0.2;
+    self.rangeSlider.leftValue = 0.0;
+    self.rangeSlider.rightValue = 0.1;
+    XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should be equal to left value plus minimum distance");
+}
 
 - (void)testSetRightValueExceedsMinimumDistance
 {


### PR DESCRIPTION
I had some use cases for pushable controls and disabling overlapping of the thumb controls, thought you might want to merge them in. 
Pushing:
![pushable](https://cloud.githubusercontent.com/assets/930469/6900708/0c824c38-d711-11e4-91b6-23370f5ebdb6.gif)
Overlapping:
![overlap](https://cloud.githubusercontent.com/assets/930469/6900717/13fa6f0e-d711-11e4-9f83-115dae437264.gif)
