### PR TITLE
Drop modules import

### DIFF
--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @interface MARKRangeSlider : UIControl
 


### PR DESCRIPTION
Modules are horribly broken in Objective-C++. Fixes issue #8 
