### PR TITLE
Feature/min max values

### DIFF
--- a/Demo/Demo/Source/Controllers/ViewController.m
+++ b/Demo/Demo/Source/Controllers/ViewController.m
@@ -63,10 +63,10 @@ static CGFloat const kViewControllerLabelWidth = 100.0;
     [self.rangeSlider addTarget:self
                          action:@selector(rangeSliderValueDidChange:)
                forControlEvents:UIControlEventValueChanged];
-    self.rangeSlider.minimumValue = 0.0;
-    self.rangeSlider.maximumValue = 1.0;
-    self.rangeSlider.leftValue = 0.2;
-    self.rangeSlider.rightValue = 0.7;
+
+    [self.rangeSlider setMinValue:0.0 maxValue:1.0];
+    [self.rangeSlider setLeftValue:0.2 rightValue:0.7];
+
     self.rangeSlider.minimumDistance = 0.2;
 
     [self updateRangeText];

--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ Please check Demo project for a basic example on how to use MARKRangeSlider.
 ![Alt text](https://cloud.githubusercontent.com/assets/10529867/6666031/88515f20-cbe0-11e4-83d7-a8bca824ab67.gif "Demo")
 
 ### Available control properties
-- `minimumValue` - the minimum value of the slider's range
-- `maximumValue` - the maximum value of the slider's range
-- `leftValue` - the value of the left thumb
-- `rightValue` - the value of the right thumb
+- `minimumValue` - the minimum value of the slider's range (readonly)
+- `maximumValue` - the maximum value of the slider's range (readonly)
+- `leftValue` - the value of the left thumb (readonly)
+- `rightValue` - the value of the right thumb (readonly)
 - `minimumDistance` - the distance between 2 thumbs (thumbs can't be closer to each other than this distance)
 - `pushable` - allows the user to push both controls
 - `disableOverlapping` - disables the overlaping of thumb controls
+
+### Available control methods
+- `(void)setMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue`
+- `(void)setLeftValue:(CGFloat)leftValue rightValue:(CGFloat)rightValue`
 
 ## Available styling properties
 Images are customizable, default ones are used when no image is provided.
@@ -37,10 +41,10 @@ Images are customizable, default ones are used when no image is provided.
     [self.rangeSlider addTarget:self
                          action:@selector(rangeSliderValueDidChange:)
                forControlEvents:UIControlEventValueChanged];
-    self.rangeSlider.minimumValue = 0.0;
-    self.rangeSlider.maximumValue = 1.0;
-    self.rangeSlider.leftValue = 0.2;
-    self.rangeSlider.rightValue = 0.7;
+
+    [self.rangeSlider setMinValue:0.0 maxValue:1.0];
+    [self.rangeSlider setLeftValue:0.2 rightValue:0.7];
+
     self.rangeSlider.minimumDistance = 0.2;
 
     [self.view addSubview:self.rangeSlider];

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -6,8 +6,8 @@
 @property (nonatomic, assign, readonly) CGFloat minimumValue;
 @property (nonatomic, assign, readonly) CGFloat maximumValue;
 
-@property (nonatomic, assign) CGFloat leftValue;
-@property (nonatomic, assign) CGFloat rightValue;
+@property (nonatomic, assign, readonly) CGFloat leftValue;
+@property (nonatomic, assign, readonly) CGFloat rightValue;
 
 @property (nonatomic, assign) CGFloat minimumDistance;
 
@@ -22,6 +22,7 @@
 @property (nonatomic) UIImage *rightThumbImage;
 
 // Configuration
-- (void)setRangeWithMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue;
+- (void)setMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue;
+- (void)setLeftValue:(CGFloat)leftValue rightValue:(CGFloat)rightValue;
 
 @end

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -3,8 +3,6 @@
 @interface MARKRangeSlider : UIControl
 
 // Values
-@property (nonatomic, assign) CGFloat minimumValue;
-@property (nonatomic, assign) CGFloat maximumValue;
 
 @property (nonatomic, assign) CGFloat leftValue;
 @property (nonatomic, assign) CGFloat rightValue;

--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -3,6 +3,8 @@
 @interface MARKRangeSlider : UIControl
 
 // Values
+@property (nonatomic, assign, readonly) CGFloat minimumValue;
+@property (nonatomic, assign, readonly) CGFloat maximumValue;
 
 @property (nonatomic, assign) CGFloat leftValue;
 @property (nonatomic, assign) CGFloat rightValue;
@@ -18,5 +20,8 @@
 
 @property (nonatomic) UIImage *leftThumbImage;
 @property (nonatomic) UIImage *rightThumbImage;
+
+// Configuration
+- (void)setRangeWithMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue;
 
 @end

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -45,9 +45,14 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 
 #pragma mark - Public
 
-- (void)setRangeWithMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue {
+- (void)setMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue {
     self.maximumValue = maxValue;
     self.minimumValue = minValue;
+}
+
+- (void)setLeftValue:(CGFloat)leftValue rightValue:(CGFloat)rightValue {
+    self.rightValue = rightValue;
+    self.leftValue = leftValue;
 }
 
 #pragma mark - Configuration

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -6,9 +6,6 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 
 @interface MARKRangeSlider ()
 
-@property (nonatomic, assign) CGFloat minimumValue;
-@property (nonatomic, assign) CGFloat maximumValue;
-
 @property (nonatomic) UIImageView *trackImageView;
 @property (nonatomic) UIImageView *rangeImageView;
 
@@ -44,6 +41,13 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
         [self setUpViewComponents];
     }
     return self;
+}
+
+#pragma mark - Public
+
+- (void)setRangeWithMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue {
+  self.maximumValue = maxValue;
+  self.minimumValue = minValue;
 }
 
 #pragma mark - Configuration

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -46,8 +46,8 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 #pragma mark - Public
 
 - (void)setRangeWithMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue {
-  self.maximumValue = maxValue;
-  self.minimumValue = minValue;
+    self.maximumValue = maxValue;
+    self.minimumValue = minValue;
 }
 
 #pragma mark - Configuration

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -6,6 +6,9 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 
 @interface MARKRangeSlider ()
 
+@property (nonatomic, assign) CGFloat minimumValue;
+@property (nonatomic, assign) CGFloat maximumValue;
+
 @property (nonatomic) UIImageView *trackImageView;
 @property (nonatomic) UIImageView *rangeImageView;
 
@@ -92,7 +95,7 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 - (CGSize)intrinsicContentSize {
     CGFloat width = _trackImage.size.width + _leftThumbImage.size.width + _rightThumbImage.size.width;
     CGFloat height = MAX(_leftThumbImage.size.height, _rightThumbImage.size.height);
-    
+
     return CGSizeMake(width, height);
 }
 
@@ -101,7 +104,7 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
     // Calculate coords & sizes
     CGFloat width = CGRectGetWidth(self.frame);
     CGFloat height = CGRectGetHeight(self.frame);
-    
+
     CGFloat trackHeight = _trackImage.size.height;
 
     CGSize leftThumbImageSize = self.leftThumbImageView.frame.size;

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -121,7 +121,7 @@
 		14C418121A01919C00636FD6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Vadym Markov";
 				TargetAttributes = {
 					14C418251A01919C00636FD6 = {
@@ -193,6 +193,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -269,6 +270,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vmarkov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -282,6 +284,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.vmarkov.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,15 +39,18 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Tests/Tests/Info.plist
+++ b/Tests/Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.vmarkov.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Tests/Tests/MARKRangeSliderTests.m
+++ b/Tests/Tests/MARKRangeSliderTests.m
@@ -64,26 +64,26 @@
 
 - (void)testSetMinimumValueGreaterThanOeEqualToMaximumValue
 {
-    [self.rangeSlider setRangeWithMinValue:1.2f maxValue:1.0f];
+    [self.rangeSlider setMinValue:1.2f maxValue:1.0f];
 
     XCTAssertEqual(self.rangeSlider.minimumValue, self.rangeSlider.maximumValue - self.rangeSlider.minimumDistance, @"Minimum value should be less than maximum value");
 
-    [self.rangeSlider setRangeWithMinValue:1.0f maxValue:1.0f];
+    [self.rangeSlider setMinValue:1.0f maxValue:1.0f];
     XCTAssertEqual(self.rangeSlider.minimumValue, self.rangeSlider.maximumValue - self.rangeSlider.minimumDistance, @"Minimum value should be less than maximum value");
 }
 
 - (void)testSetMinimumValueGreaterThanLeftValue
 {
-    self.rangeSlider.leftValue = 0.3;
-    [self.rangeSlider setRangeWithMinValue:0.4f maxValue:1.0f];
+    [self.rangeSlider setLeftValue:0.3 rightValue:1.0];
+    [self.rangeSlider setMinValue:0.4f maxValue:1.0f];
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should be equal to minimum value");
 }
 
 - (void)testSetMinimumValueGreaterThanRightValue
 {
-    self.rangeSlider.rightValue = 1.0;
-    [self.rangeSlider setRangeWithMinValue:1.2f maxValue:1.0f];
+    [self.rangeSlider setLeftValue:0.0 rightValue:1.0];
+    [self.rangeSlider setMinValue:1.2f maxValue:1.0f];
 
     XCTAssertGreaterThanOrEqual(self.rangeSlider.rightValue, self.rangeSlider.minimumValue, @"Right value should be greater than or equal to minimum value");
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should be equal to maximum value");
@@ -93,18 +93,18 @@
 
 - (void)testSetMaximumValueLessThanOeEqualToMinimumValue
 {
-    [self.rangeSlider setRangeWithMinValue:0.5f maxValue:0.4f];
+    [self.rangeSlider setMinValue:0.5f maxValue:0.4f];
 
     XCTAssertEqual(self.rangeSlider.maximumValue, self.rangeSlider.minimumValue + self.rangeSlider.minimumDistance, @"Maximum value should be greater than maximum value");
 
-    [self.rangeSlider setRangeWithMinValue:0.5f maxValue:0.5f];
+    [self.rangeSlider setMinValue:0.5f maxValue:0.5f];
     XCTAssertEqual(self.rangeSlider.maximumValue, self.rangeSlider.minimumValue + self.rangeSlider.minimumDistance, @"Maximum value should be greater than maximum value");
 }
 
 - (void)testSetMaximumValueLessThanLeftValue
 {
-    self.rangeSlider.leftValue = 0.3;
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:0.2f];
+    [self.rangeSlider setLeftValue:0.3 rightValue:1.0];
+    [self.rangeSlider setMinValue:0.0f maxValue:0.2f];
 
     XCTAssertLessThan(self.rangeSlider.leftValue, self.rangeSlider.maximumValue, @"Left value should be less than maximum value");
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should be equal to minimum value");
@@ -112,8 +112,8 @@
 
 - (void)testSetMaximumValueLessThanRightValue
 {
-    self.rangeSlider.rightValue = 1.0;
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:0.8f];
+    [self.rangeSlider setLeftValue:0.0 rightValue:1.0];
+    [self.rangeSlider setMinValue:0.0f maxValue:0.8f];
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should be equal to maximum value");
 }
@@ -123,36 +123,34 @@
 - (void)testSetLeftValuePushesRightValue
 {
     self.rangeSlider.pushable = YES;
-    self.rangeSlider.rightValue = 0.7;
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.6;
+    [self.rangeSlider setLeftValue:0.6 rightValue:0.7];
+
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should be equal to left value plus minimum distance");
 }
 
 - (void)testSetLeftValueDoesntPushRightValue
 {
     self.rangeSlider.pushable = YES;
-    self.rangeSlider.rightValue = 1.0;
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.9;
+    [self.rangeSlider setLeftValue:0.9 rightValue:1.0];
+
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should be equal to right value minus minimum distance");
 }
 
 - (void)testSetLeftValueExceedsMinimumDistance
 {
-    self.rangeSlider.rightValue = 1.0;
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.9;
+    [self.rangeSlider setLeftValue:0.9 rightValue:1.0];
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should not exceed minimum distance with right value");
 }
 
 - (void)testSetLeftValueExceedsMinimumDistanceAndLessThanMinimumValue
 {
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
+    [self.rangeSlider setMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.rightValue = 0.1;
-    self.rangeSlider.leftValue = 0.1;
+    [self.rangeSlider setLeftValue:0.1 rightValue:0.1];
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should not exceed minimum distance with right value");
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should be equal to minimum value");
@@ -160,8 +158,8 @@
 
 - (void)testSetLeftValueLessThanMinimumValue
 {
-    [self.rangeSlider setRangeWithMinValue:0.2f maxValue:1.0f];
-    self.rangeSlider.leftValue = 0.1;
+    [self.rangeSlider setMinValue:0.2f maxValue:1.0f];
+    [self.rangeSlider setLeftValue:0.1 rightValue:1.0];
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should not be less than minimum value");
 }
@@ -171,9 +169,9 @@
 - (void)testSetRightValuePushesLeftValue
 {
     self.rangeSlider.pushable = YES;
-    self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.6;
-    self.rangeSlider.rightValue = 0.7;
+    self.rangeSlider.minimumDistance = 0.2f;
+    [self.rangeSlider setLeftValue:0.6f rightValue:0.7f];
+
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.rightValue - self.rangeSlider.minimumDistance, @"Left value should be equal to right value minus minimum distance");
 }
 
@@ -181,44 +179,40 @@
 {
     self.rangeSlider.pushable = YES;
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.0;
-    self.rangeSlider.rightValue = 0.1;
+    [self.rangeSlider setLeftValue:0.0 rightValue:0.1];
+
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should be equal to left value plus minimum distance");
 }
 
 - (void)testSetRightValueExceedsMinimumDistance
 {
-    self.rangeSlider.leftValue = 0.5;
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.rightValue = 0.6;
+    [self.rangeSlider setLeftValue:0.5 rightValue:0.6];
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should not exceed minimum distance with left value");
 }
 
 - (void)testSetRightValueGreaterThanMaximumValue
 {
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
-    self.rangeSlider.rightValue = 1.1;
+    [self.rangeSlider setMinValue:0.0f maxValue:1.0f];
+    [self.rangeSlider setLeftValue:0.0 rightValue:1.1];
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should not be greater than maximum value");
 }
 
 - (void)testSetRightValueExceedsMinimumDistanceAndGreaterThanMaximumValue
 {
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
-    self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.leftValue = 0.9;
-    self.rangeSlider.rightValue = 0.9;
+    [self.rangeSlider setMinValue:0.0f maxValue:1.0f];
+    [self.rangeSlider setLeftValue:0.9f rightValue:0.9f];
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.leftValue + self.rangeSlider.minimumDistance, @"Right value should not exceed minimum distance with left value");
-    XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should be equal to maximum value");
 }
 
 #pragma mark - Minimum distance tests
 
 - (void)testSetMinimumDistanceGreaterThanRangeDistance
 {
-    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
+    [self.rangeSlider setMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.minimumDistance = 2.0;
 
     XCTAssertEqual(self.rangeSlider.minimumDistance, self.rangeSlider.maximumValue - self.rangeSlider.minimumValue, @"Minimum distance should not exceed range distance");
@@ -226,8 +220,7 @@
 
 - (void)testSetMinimumDistanceConflictsWithDistanceBetweenRightAndLeftValues
 {
-    self.rangeSlider.leftValue = 0.2;
-    self.rangeSlider.rightValue = 0.5;
+    [self.rangeSlider setLeftValue:0.2 rightValue:0.5];
     self.rangeSlider.minimumDistance = 0.5;
 
     XCTAssertEqual(self.rangeSlider.minimumDistance, 0.5, @"Minimum distance does not set properly");
@@ -266,7 +259,7 @@
 - (void)testCheckMinimumDistance
 {
     self.rangeSlider.minimumDistance = 0.2;
-    [self.rangeSlider setRangeWithMinValue:0.4f maxValue:0.5f];
+    [self.rangeSlider setMinValue:0.4f maxValue:0.5f];
 
     XCTAssertEqual(self.rangeSlider.minimumDistance, 0.0f, @"Minimum distance should be equal to 0.0");
 }

--- a/Tests/Tests/MARKRangeSliderTests.m
+++ b/Tests/Tests/MARKRangeSliderTests.m
@@ -64,18 +64,18 @@
 
 - (void)testSetMinimumValueGreaterThanOeEqualToMaximumValue
 {
-    self.rangeSlider.maximumValue = 1.0f;
-    self.rangeSlider.minimumValue = 1.2f;
+    [self.rangeSlider setRangeWithMinValue:1.2f maxValue:1.0f];
 
     XCTAssertEqual(self.rangeSlider.minimumValue, self.rangeSlider.maximumValue - self.rangeSlider.minimumDistance, @"Minimum value should be less than maximum value");
-    self.rangeSlider.minimumValue = 1.0;
+
+    [self.rangeSlider setRangeWithMinValue:1.0f maxValue:1.0f];
     XCTAssertEqual(self.rangeSlider.minimumValue, self.rangeSlider.maximumValue - self.rangeSlider.minimumDistance, @"Minimum value should be less than maximum value");
 }
 
 - (void)testSetMinimumValueGreaterThanLeftValue
 {
     self.rangeSlider.leftValue = 0.3;
-    self.rangeSlider.minimumValue = 0.4;
+    [self.rangeSlider setRangeWithMinValue:0.4f maxValue:1.0f];
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should be equal to minimum value");
 }
@@ -83,7 +83,7 @@
 - (void)testSetMinimumValueGreaterThanRightValue
 {
     self.rangeSlider.rightValue = 1.0;
-    self.rangeSlider.minimumValue = 1.2;
+    [self.rangeSlider setRangeWithMinValue:1.2f maxValue:1.0f];
 
     XCTAssertGreaterThanOrEqual(self.rangeSlider.rightValue, self.rangeSlider.minimumValue, @"Right value should be greater than or equal to minimum value");
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should be equal to maximum value");
@@ -93,18 +93,18 @@
 
 - (void)testSetMaximumValueLessThanOeEqualToMinimumValue
 {
-    self.rangeSlider.minimumValue = 0.5;
-    self.rangeSlider.maximumValue = 0.4;
+    [self.rangeSlider setRangeWithMinValue:0.5f maxValue:0.4f];
 
     XCTAssertEqual(self.rangeSlider.maximumValue, self.rangeSlider.minimumValue + self.rangeSlider.minimumDistance, @"Maximum value should be greater than maximum value");
-    self.rangeSlider.maximumValue = 0.5;
+
+    [self.rangeSlider setRangeWithMinValue:0.5f maxValue:0.5f];
     XCTAssertEqual(self.rangeSlider.maximumValue, self.rangeSlider.minimumValue + self.rangeSlider.minimumDistance, @"Maximum value should be greater than maximum value");
 }
 
 - (void)testSetMaximumValueLessThanLeftValue
 {
     self.rangeSlider.leftValue = 0.3;
-    self.rangeSlider.maximumValue = 0.2;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:0.2f];
 
     XCTAssertLessThan(self.rangeSlider.leftValue, self.rangeSlider.maximumValue, @"Left value should be less than maximum value");
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should be equal to minimum value");
@@ -113,7 +113,7 @@
 - (void)testSetMaximumValueLessThanRightValue
 {
     self.rangeSlider.rightValue = 1.0;
-    self.rangeSlider.maximumValue = 0.8;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:0.8f];
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should be equal to maximum value");
 }
@@ -149,8 +149,7 @@
 
 - (void)testSetLeftValueExceedsMinimumDistanceAndLessThanMinimumValue
 {
-    self.rangeSlider.minimumValue = 0.0;
-    self.rangeSlider.maximumValue = 1.0;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.minimumDistance = 0.2;
     self.rangeSlider.rightValue = 0.1;
     self.rangeSlider.leftValue = 0.1;
@@ -161,7 +160,7 @@
 
 - (void)testSetLeftValueLessThanMinimumValue
 {
-    self.rangeSlider.minimumValue = 0.2;
+    [self.rangeSlider setRangeWithMinValue:0.2f maxValue:1.0f];
     self.rangeSlider.leftValue = 0.1;
 
     XCTAssertEqual(self.rangeSlider.leftValue, self.rangeSlider.minimumValue, @"Left value should not be less than minimum value");
@@ -198,7 +197,7 @@
 
 - (void)testSetRightValueGreaterThanMaximumValue
 {
-    self.rangeSlider.maximumValue = 1.0;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.rightValue = 1.1;
 
     XCTAssertEqual(self.rangeSlider.rightValue, self.rangeSlider.maximumValue, @"Right value should not be greater than maximum value");
@@ -206,8 +205,7 @@
 
 - (void)testSetRightValueExceedsMinimumDistanceAndGreaterThanMaximumValue
 {
-    self.rangeSlider.minimumValue = 0.0;
-    self.rangeSlider.maximumValue = 1.0;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.minimumDistance = 0.2;
     self.rangeSlider.leftValue = 0.9;
     self.rangeSlider.rightValue = 0.9;
@@ -220,8 +218,7 @@
 
 - (void)testSetMinimumDistanceGreaterThanRangeDistance
 {
-    self.rangeSlider.minimumValue = 0.0;
-    self.rangeSlider.maximumValue = 1.0;
+    [self.rangeSlider setRangeWithMinValue:0.0f maxValue:1.0f];
     self.rangeSlider.minimumDistance = 2.0;
 
     XCTAssertEqual(self.rangeSlider.minimumDistance, self.rangeSlider.maximumValue - self.rangeSlider.minimumValue, @"Minimum distance should not exceed range distance");
@@ -269,8 +266,7 @@
 - (void)testCheckMinimumDistance
 {
     self.rangeSlider.minimumDistance = 0.2;
-    self.rangeSlider.minimumValue = 0.4;
-    self.rangeSlider.maximumValue = 0.5;
+    [self.rangeSlider setRangeWithMinValue:0.4f maxValue:0.5f];
 
     XCTAssertEqual(self.rangeSlider.minimumDistance, 0.0f, @"Minimum distance should be equal to 0.0");
 }


### PR DESCRIPTION
Public API is updated to fix https://github.com/vadymmarkov/MARKRangeSlider/issues/18 and https://github.com/vadymmarkov/MARKRangeSlider/issues/5

From now the following methods should be used to prevent issues with the required order of setting properties:

``` objc
- (void)setMinValue:(CGFloat)minValue maxValue:(CGFloat)maxValue;
- (void)setLeftValue:(CGFloat)leftValue rightValue:(CGFloat)rightValue;
```
