### PR TITLE
Exposes read-only properties of left/right thumb views.

### DIFF
--- a/Source/MARKRangeSlider.h
+++ b/Source/MARKRangeSlider.h
@@ -9,6 +9,9 @@
 @property (nonatomic, assign, readonly) CGFloat leftValue;
 @property (nonatomic, assign, readonly) CGFloat rightValue;
 
+@property (nonatomic, readonly) UIView *leftThumbView;
+@property (nonatomic, readonly) UIView *rightThumbView;
+
 @property (nonatomic, assign) CGFloat minimumDistance;
 
 @property (nonatomic) BOOL pushable;

--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -212,6 +212,16 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
 
 #pragma mark - Getters
 
+- (UIView *)leftThumbView
+{
+    return self.leftThumbImageView;
+}
+
+- (UIView *)rightThumbView
+{
+    return self.rightThumbImageView;
+}
+
 - (UIImage *)trackImage
 {
     if (!_trackImage) {


### PR DESCRIPTION
This is really beneficial because you can attach auto layout constraints to other views, like this:

![2016-01-27 14_47_16](https://cloud.githubusercontent.com/assets/498212/12627803/d6fdac88-c50d-11e5-99e9-408292922944.gif)
