### PR TITLE
Make the thumb image view size equal to image size

### DIFF
--- a/Source/MARKRangeSlider.m
+++ b/Source/MARKRangeSlider.m
@@ -160,6 +160,12 @@ static NSString * const kMARKRangeSliderTrackRangeImage = @"rangeSliderTrackRang
     }
     self.rangeImageView.frame = CGRectMake(leftX + leftInset, trackY, rangeWidth, trackHeight);
 
+    // Set thumb image view frame sizes
+    CGRect leftImageViewFrame = { CGPointMake(0, 0), leftThumbImageSize };
+    CGRect rightImageViewFrame = { CGPointMake(0, 0), rightThumbImageSize };
+    self.leftThumbImageView.frame = leftImageViewFrame;
+    self.rightThumbImageView.frame = rightImageViewFrame;
+
     // Set left & right thumb frames
     leftX += leftInset;
     rightX += rightInset;


### PR DESCRIPTION
Problem: even if the thumb image is quite big the image view frame remains `32x32` (as bundle image). Therefore we cannot easily pan the thumb.
This PR changes the image view frame sizes. And fixes https://github.com/vadymmarkov/MARKRangeSlider/issues/25
Thanks.
